### PR TITLE
Enable runtime changes to tcmalloc sampling parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,5 @@
 /test-driver
 /thread_dealloc_unittest
 /thread_dealloc_unittest.exe
+
+.vscode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_minimum_required(VERSION 3.12)
 
 # Based on configure.ac
 
-project(gperftools VERSION 2.8.1-yb-4 LANGUAGES C CXX
+project(gperftools VERSION 2.8.1-yb-5 LANGUAGES C CXX
         DESCRIPTION "Performance tools for C++"
         HOMEPAGE_URL http://code.google.com/p/gperftools/)
 

--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@
 # make sure we're interpreted by some minimal autoconf
 AC_PREREQ([2.59])
 
-AC_INIT([gperftools],[2.8.1-yb-4],[gperftools@googlegroups.com])
+AC_INIT([gperftools],[2.8.1-yb-5],[gperftools@googlegroups.com])
 # Update this value for every release!  (A:B:C will map to foo.so.(A-C).C.B)
 # http://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html
 TCMALLOC_SO_VERSION=9:6:5

--- a/src/gperftools/malloc_extension.h
+++ b/src/gperftools/malloc_extension.h
@@ -237,6 +237,12 @@ class PERFTOOLS_DLL_DECL MallocExtension {
   // REQUIRES: property != NULL
   virtual bool SetNumericProperty(const char* property, size_t value);
 
+  virtual int64_t GetProfileSamplingRate();
+
+  // Sets the sampling rate for heap profiles.  TCMalloc samples approximately
+  // every sample_period bytes allocated.
+  virtual void SetProfileSamplingRate(int64_t sample_period);
+
   // Mark the current thread as "idle".  This routine may optionally
   // be called by threads as a hint to the malloc implementation that
   // any thread-specific resources should be released.  Note: this may

--- a/src/gperftools/malloc_extension.h
+++ b/src/gperftools/malloc_extension.h
@@ -239,7 +239,7 @@ class PERFTOOLS_DLL_DECL MallocExtension {
 
   virtual int64_t GetProfileSamplingRate();
 
-  // Sets the sampling rate for heap profiles.  TCMalloc samples approximately
+  // Sets the sampling rate for heap profiles. TCMalloc samples approximately
   // every sample_period bytes allocated.
   virtual void SetProfileSamplingRate(int64_t sample_period);
 

--- a/src/malloc_extension.cc
+++ b/src/malloc_extension.cc
@@ -122,6 +122,16 @@ bool MallocExtension::SetNumericProperty(const char* property, size_t value) {
   return false;
 }
 
+int64_t MallocExtension::GetProfileSamplingRate() {
+  return 0;
+}
+
+// Sets the sampling rate for heap profiles. TCMalloc samples approximately
+// every sample_period bytes allocated.
+void MallocExtension::SetProfileSamplingRate(int64_t sample_period) {
+  return;
+}
+
 void MallocExtension::GetStats(char* buffer, int length) {
   assert(length > 0);
   buffer[0] = '\0';

--- a/src/static_vars.cc
+++ b/src/static_vars.cc
@@ -76,6 +76,7 @@ PageHeapAllocator<StackTrace> Static::stacktrace_allocator_;
 Span Static::sampled_objects_;
 StackTrace* Static::growth_stacks_ = NULL;
 Static::PageHeapStorage Static::pageheap_;
+std::atomic<int64_t> Static::sample_period_;
 
 void Static::InitStaticVars() {
   sizemap_.Init();
@@ -104,6 +105,8 @@ void Static::InitStaticVars() {
                          kDefaultAggressiveDecommit);
 
   pageheap()->SetAggressiveDecommit(aggressive_decommit);
+
+  sample_period_ = 0;
 
   inited_ = true;
 

--- a/src/static_vars.h
+++ b/src/static_vars.h
@@ -90,7 +90,8 @@ class Static {
     return sample_period_.load(std::memory_order_relaxed);
   }
   static void set_sample_period(int64_t rate) {
-    sample_period_.store(rate, std::memory_order_relaxed);
+    // This is not on any performance-intensive paths, so sequential consistency is fine.
+    sample_period_.store(rate, std::memory_order_seq_cst);
   }
 
   // Check if InitStaticVars() has been run.

--- a/src/static_vars.h
+++ b/src/static_vars.h
@@ -87,11 +87,9 @@ class Static {
   static Span* sampled_objects() { return &sampled_objects_; }
 
   static int64_t get_sample_period() {
-    // return sample_period_;
     return sample_period_.load(std::memory_order_relaxed);
   }
   static void set_sample_period(int64_t rate) {
-    // sample_period_ = store(rate, std::memory_order_relaxed);
     sample_period_.store(rate, std::memory_order_relaxed);
   }
 

--- a/src/static_vars.h
+++ b/src/static_vars.h
@@ -36,6 +36,8 @@
 #ifndef TCMALLOC_STATIC_VARS_H_
 #define TCMALLOC_STATIC_VARS_H_
 
+#include <atomic>
+
 #include <config.h>
 #include "base/basictypes.h"
 #include "base/spinlock.h"
@@ -84,6 +86,15 @@ class Static {
   // State kept for sampled allocations (/pprof/heap support)
   static Span* sampled_objects() { return &sampled_objects_; }
 
+  static int64_t get_sample_period() {
+    // return sample_period_;
+    return sample_period_.load(std::memory_order_relaxed);
+  }
+  static void set_sample_period(int64_t rate) {
+    // sample_period_ = store(rate, std::memory_order_relaxed);
+    sample_period_.store(rate, std::memory_order_relaxed);
+  }
+
   // Check if InitStaticVars() has been run.
   static bool IsInited() { return inited_; }
 
@@ -119,6 +130,8 @@ class Static {
     uintptr_t extra;  // To force alignment
   };
   ATTRIBUTE_HIDDEN static PageHeapStorage pageheap_;
+
+  static std::atomic<int64_t> sample_period_;
 };
 
 }  // namespace tcmalloc

--- a/src/tcmalloc.cc
+++ b/src/tcmalloc.cc
@@ -860,7 +860,7 @@ class TCMallocImplementation : public MallocExtension {
     return Static::get_sample_period();
   }
 
-  // Sets the sampling rate for heap profiles.  TCMalloc samples approximately
+  // Sets the sampling rate for heap profiles. TCMalloc samples approximately
   // every sample_period bytes allocated.
   virtual void SetProfileSamplingRate(int64_t sample_period) {
     Static::set_sample_period(sample_period);

--- a/src/tcmalloc.cc
+++ b/src/tcmalloc.cc
@@ -650,7 +650,7 @@ class TCMallocImplementation : public MallocExtension {
 
   // We may print an extra, tcmalloc-specific warning message here.
   virtual void GetHeapSample(MallocExtensionWriter* writer) {
-    if (FLAGS_tcmalloc_sample_parameter == 0) {
+    if (Static::get_sample_period() == 0) {
       const char* const kWarningMsg =
           "%warn\n"
           "%warn This heap profile does not have any data in it, because\n"
@@ -854,6 +854,16 @@ class TCMallocImplementation : public MallocExtension {
     }
 
     return false;
+  }
+
+  virtual int64_t GetProfileSamplingRate() {
+    return Static::get_sample_period();
+  }
+
+  // Sets the sampling rate for heap profiles.  TCMalloc samples approximately
+  // every sample_period bytes allocated.
+  virtual void SetProfileSamplingRate(int64_t sample_period) {
+    Static::set_sample_period(sample_period);
   }
 
   virtual void MarkThreadIdle() {

--- a/src/tests/sampler_test.cc
+++ b/src/tests/sampler_test.cc
@@ -622,10 +622,9 @@ TEST(Sample, size_of_class) {
 }
 
 // Make sure sampling is enabled, or the tests won't work right.
-DECLARE_int64(tcmalloc_sample_parameter);
 
 int main(int argc, char **argv) {
-  if (FLAGS_tcmalloc_sample_parameter == 0)
-    FLAGS_tcmalloc_sample_parameter = 524288;
+  if (MallocExtension::instance()->GetProfileSamplingRate() == 0)
+    MallocExtension::instance()->SetProfileSamplingRate(524288);
   return RUN_ALL_TESTS();
 }

--- a/src/tests/tcmalloc_unittest.cc
+++ b/src/tests/tcmalloc_unittest.cc
@@ -654,8 +654,8 @@ static void TestRealloc() {
   // makes reallocs of small sizes do extra work (thus, failing these
   // checks).  Since sampling is random, we turn off sampling to make
   // sure that doesn't happen to us here.
-  const int64 old_sample_parameter = FLAGS_tcmalloc_sample_parameter;
-  FLAGS_tcmalloc_sample_parameter = 0;   // turn off sampling
+  const int64 old_sample_parameter = MallocExtension::instance()->GetProfileSamplingRate();
+  MallocExtension::instance()->SetProfileSamplingRate(0);   // turn off sampling
 
   int start_sizes[] = { 100, 1000, 10000, 100000 };
   int deltas[] = { 1, -2, 4, -8, 16, -32, 64, -128 };
@@ -675,7 +675,7 @@ static void TestRealloc() {
     }
     free(p);
   }
-  FLAGS_tcmalloc_sample_parameter = old_sample_parameter;
+  MallocExtension::instance()->SetProfileSamplingRate(old_sample_parameter);
 #endif
 }
 

--- a/src/thread_cache.h
+++ b/src/thread_cache.h
@@ -58,8 +58,6 @@
 #include "sampler.h"           // for Sampler
 #include "static_vars.h"       // for Static
 
-DECLARE_int64(tcmalloc_sample_parameter);
-
 namespace tcmalloc {
 
 //-------------------------------------------------------------------

--- a/src/windows/config.h
+++ b/src/windows/config.h
@@ -254,7 +254,7 @@
 #define PACKAGE_NAME "gperftools"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "gperftools 2.8.1-yb-4"
+#define PACKAGE_STRING "gperftools 2.8.1-yb-5"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "gperftools"
@@ -263,7 +263,7 @@
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "2.8.1-yb-4"
+#define PACKAGE_VERSION "2.8.1-yb-5"
 
 /* How to access the PC from a struct ucontext */
 /* #undef PC_FROM_UCONTEXT */

--- a/src/windows/gperftools/tcmalloc.h
+++ b/src/windows/gperftools/tcmalloc.h
@@ -45,7 +45,7 @@
 #define TC_VERSION_MAJOR  2
 #define TC_VERSION_MINOR  8
 #define TC_VERSION_PATCH  ".1"
-#define TC_VERSION_STRING "gperftools 2.8.1-yb-4"
+#define TC_VERSION_STRING "gperftools 2.8.1-yb-5"
 
 #ifndef PERFTOOLS_NOTHROW
 


### PR DESCRIPTION
Before this diff, the tcmalloc sampling interval was defined by FLAGS_tcmalloc_sample_parameter, which had no atomic guards around modifying it. (NB: This uses commandlineflags.h defined in this repository, not gflags). This commit changes it to a static variable and adds an API to MallocExtension so that it can be safely get/set at runtime.